### PR TITLE
Add local experience detail pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,8 @@ import HomePage from './pages/HomePage';
 import ServicesPage from './pages/ServicesPage';
 import ContactPage from './pages/ContactPage'; // Now this file exists
 import PrivacyPolicyPage from './pages/PrivacyPolicyPage'; // Now this file exists
-import LocalExpPage from './pages/LocalExpPage'; // Now this file exists
+import LocalExpPage from './pages/LocalExpPage';
+import LocalExpDetailPage from './pages/LocalExpDetailPage';
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
             <Route path="/contact" element={<ContactPage />} />
             <Route path="/privacy" element={<PrivacyPolicyPage />} />
             <Route path="/local-exp" element={<LocalExpPage />} />
+            <Route path="/local-exp/:slug" element={<LocalExpDetailPage />} />
           </Routes>
         </Layout>
       </Router>

--- a/src/data/localExperiences.js
+++ b/src/data/localExperiences.js
@@ -1,0 +1,38 @@
+export const localExperiences = [
+  {
+    slug: 'marrakech-luxury-riads',
+    title: 'Marrakech Luxury Riads',
+    description: 'Experience authentic Moroccan hospitality in beautifully restored traditional houses.',
+    details: 'Stay in historic riads located in the heart of Marrakech and enjoy personalized service in a luxurious setting.'
+  },
+  {
+    slug: 'sahara-desert-adventures',
+    title: 'Sahara Desert Adventures',
+    description: 'Camel treks, desert camping, and star gazing in the majestic Sahara.',
+    details: 'Embark on camel rides across rolling dunes, spend nights under a starlit sky, and witness breathtaking desert landscapes.'
+  },
+  {
+    slug: 'atlas-mountain-trekking',
+    title: 'Atlas Mountain Trekking',
+    description: 'Hike through breathtaking landscapes and visit traditional Berber villages.',
+    details: 'Explore the rugged Atlas mountain range with local guides and discover the rich culture of Berber communities.'
+  },
+  {
+    slug: 'essaouira-coastal-charm',
+    title: 'Essaouira Coastal Charm',
+    description: 'Relax in this charming coastal town with its blue fishing boats and fresh seafood.',
+    details: 'Stroll through the fortified medina, watch the vibrant fishing port in action, and sample fresh Atlantic seafood.'
+  },
+  {
+    slug: 'fes-cultural-immersion',
+    title: 'Fes Cultural Immersion',
+    description: "Explore the world's oldest medieval city and its vibrant artisan quarters.",
+    details: 'Lose yourself in narrow alleys of the Fes medina and meet artisans preserving centuries-old crafts.'
+  },
+  {
+    slug: 'chefchaouen-blue-city',
+    title: 'Chefchaouen Blue City',
+    description: "Discover the magical blue-washed streets of Morocco's most photogenic city.",
+    details: 'Wander through blue-hued alleys, enjoy panoramic mountain views, and experience this unique destination.'
+  }
+];

--- a/src/pages/LocalExpDetailPage.jsx
+++ b/src/pages/LocalExpDetailPage.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { localExperiences } from '../data/localExperiences';
+
+const LocalExpDetailPage = () => {
+  const { slug } = useParams();
+  const exp = localExperiences.find((e) => e.slug === slug);
+
+  if (!exp) {
+    return (
+      <div className="container mx-auto px-4 py-12">
+        <p className="text-center text-gray-600">Experience not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <h1 className="text-4xl font-bold mb-4">
+        {exp.title}
+      </h1>
+      <p className="text-gray-700 mb-8">{exp.details}</p>
+      <Link to="/local-exp" className="text-primary font-semibold hover:underline">
+        &larr; Back to experiences
+      </Link>
+    </div>
+  );
+};
+
+export default LocalExpDetailPage;

--- a/src/pages/LocalExpPage.jsx
+++ b/src/pages/LocalExpPage.jsx
@@ -1,38 +1,9 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { localExperiences } from '../data/localExperiences';
 
 const LocalExpPage = () => {
-  const experiences = [
-    {
-      title: "Marrakech Luxury Riads",
-      description: "Experience authentic Moroccan hospitality in beautifully restored traditional houses.",
-      image: "/images/marrakech-riad.jpg"
-    },
-    {
-      title: "Sahara Desert Adventures",
-      description: "Camel treks, desert camping, and star gazing in the majestic Sahara.",
-      image: "/images/sahara-desert.jpg"
-    },
-    {
-      title: "Atlas Mountain Trekking",
-      description: "Hike through breathtaking landscapes and visit traditional Berber villages.",
-      image: "/images/atlas-mountains.jpg"
-    },
-    {
-      title: "Essaouira Coastal Charm",
-      description: "Relax in this charming coastal town with its blue fishing boats and fresh seafood.",
-      image: "/images/essaouira.jpg"
-    },
-    {
-      title: "Fes Cultural Immersion",
-      description: "Explore the world's oldest medieval city and its vibrant artisan quarters.",
-      image: "/images/fes-medina.jpg"
-    },
-    {
-      title: "Chefchaouen Blue City",
-      description: "Discover the magical blue-washed streets of Morocco's most photogenic city.",
-      image: "/images/chefchaouen.jpg"
-    }
-  ];
+  const experiences = localExperiences;
 
   return (
     <div className="container mx-auto px-4 py-12">
@@ -48,16 +19,20 @@ const LocalExpPage = () => {
       
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
         {experiences.map((exp, index) => (
-          <div key={index} className="bg-white rounded-xl overflow-hidden shadow-lg transition-transform hover:scale-[1.02]">
+          <Link
+            key={index}
+            to={`/local-exp/${exp.slug}`}
+            className="bg-white rounded-xl overflow-hidden shadow-lg transition-transform hover:scale-[1.02]"
+          >
             <div className="h-48 bg-gray-200 border-2 border-dashed rounded-t-xl"></div>
             <div className="p-6">
               <h3 className="text-xl font-bold mb-2">{exp.title}</h3>
               <p className="text-gray-600 mb-4">{exp.description}</p>
-              <button className="text-primary font-semibold hover:underline">
+              <span className="text-primary font-semibold hover:underline">
                 Discover Experience
-              </button>
+              </span>
             </div>
-          </div>
+          </Link>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- create shared local experience data
- add dynamic page to display an experience's details
- make cards link to their detail pages
- add router entry for experience pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6851cd65e7208323bc50ca93793d1f70