### PR TITLE
Add drop shadows to booking widgets

### DIFF
--- a/src/components/booking/BookingWidget.jsx
+++ b/src/components/booking/BookingWidget.jsx
@@ -7,7 +7,7 @@ const BookingWidget = () => {
   const { activeWidget, switchWidget } = useWidget();
 
   return (
-    <div className="bg-white rounded-2xl shadow-xl p-6 w-full max-w-4xl mx-auto">
+    <div className="bg-white rounded-2xl shadow-2xl p-6 w-full max-w-4xl mx-auto">
       <div className="mb-6 text-center">
         <div className="flex items-center justify-center mb-2">
           <img

--- a/src/components/booking/CarRentalWidget.jsx
+++ b/src/components/booking/CarRentalWidget.jsx
@@ -19,7 +19,7 @@ const CarRentalWidget = () => {
     };
   }, []);
 
-  return <div id="car-rental-widget-container" className="w-full"></div>;
+  return <div id="car-rental-widget-container" className="w-full shadow-lg"></div>;
 };
 
 export default CarRentalWidget;

--- a/src/components/booking/HotelFlightWidget.jsx
+++ b/src/components/booking/HotelFlightWidget.jsx
@@ -19,7 +19,7 @@ const HotelFlightWidget = () => {
     };
   }, []);
 
-  return <div id="hotel-flight-widget-container" className="w-full"></div>;
+  return <div id="hotel-flight-widget-container" className="w-full shadow-lg"></div>;
 };
 
 export default HotelFlightWidget;


### PR DESCRIPTION
## Summary
- make BookingWidget pop by using a stronger box shadow
- add drop shadows to the injected hotel and car rental widgets

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851df26fba08323b6e978f21550e4d2