### PR TITLE
Adjust background image scope

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -5,14 +5,16 @@ import Footer from './Footer';
 const Layout = ({ children }) => {
   return (
     <div className="relative flex flex-col min-h-screen bg-gradient-to-br from-blue-50 to-indigo-50">
-      {/* Background image */}
-      <div
-        aria-hidden="true"
-        className="absolute inset-0 bg-[url('/images/zellige.jpg')] bg-cover bg-center opacity-30 pointer-events-none"
-      ></div>
       <Navbar />
       <main className="relative flex-grow py-8">
-        {children}
+        {/* Background image only for page content */}
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-[url('/images/zellige.jpg')] bg-cover bg-center opacity-5 pointer-events-none"
+        ></div>
+        <div className="relative">
+          {children}
+        </div>
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- confine background image overlay to only the main page content
- lower overlay opacity to 5%

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852ca1efcac8323a3ad5a050d246877