### PR TITLE
Reduce top margin of BookingWidget

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -4,8 +4,8 @@ import MoroccoSection from '../components/sections/MoroccoSection';
 
 const HomePage = () => {
   return (
-    <div className="py-8">
-      <div className="container mx-auto px-4 my-12">
+    <div className="py-6">
+      <div className="container mx-auto px-4 mt-6 mb-12 sm:mt-8 md:mt-10">
         <BookingWidget />
       </div>
       <MoroccoSection />


### PR DESCRIPTION
## Summary
- reduce padding on the home page
- add responsive margin classes before the booking widget

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68532c2d576483238811b9bccb8c978d