### PR TITLE
Update TripsWidget with new script

### DIFF
--- a/src/components/booking/TripsWidget.jsx
+++ b/src/components/booking/TripsWidget.jsx
@@ -7,13 +7,9 @@ const TripsWidget = () => {
 
     const script = document.createElement('script');
     script.src =
-      'https://widgets.tiqets.com/content?currency=USD&trs=425059&shmarker=636307.636307&language=en&layout=responsive&cards=4&powered_by=true&campaign_id=89&promo_id=3947';
+      'https://tpwidg.com/content?currency=USD&trs=425059&shmarker=636307.636307&product=1106931%2C1106930%2C1114535%2C1114028&language=en&layout=horizontal&powered_by=true&campaign_id=89&promo_id=3948';
     script.async = true;
     script.charset = 'utf-8';
-    script.crossOrigin = 'anonymous';
-    script.onerror = () => {
-      container.textContent = 'Failed to load trips.';
-    };
 
     container.appendChild(script);
 


### PR DESCRIPTION
## Summary
- refresh TripsWidget code to load the new Travelpayouts widget

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68559c5550b88323ab80bad84c022ae8