### PR TITLE
Update services cards with widget links

### DIFF
--- a/src/components/booking/BookingWidget.jsx
+++ b/src/components/booking/BookingWidget.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useWidget } from '../../context/WidgetContext';
+import { useSearchParams } from 'react-router-dom';
 import HotelFlightWidget from './HotelFlightWidget';
 import CarRentalWidget from './CarRentalWidget';
 import TripsWidget from './TripsWidget';
@@ -8,9 +9,20 @@ import EsimWidget from './EsimWidget';
 
 const BookingWidget = () => {
   const { activeWidget, switchWidget } = useWidget();
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const service = searchParams.get('service');
+    if (service) {
+      switchWidget(service);
+    }
+  }, [searchParams, switchWidget]);
 
   return (
-    <div className="bg-white rounded-2xl shadow-2xl p-6 w-full max-w-4xl mx-auto">
+    <div
+      id="booking-widget"
+      className="bg-white rounded-2xl shadow-2xl p-6 w-full max-w-4xl mx-auto"
+    >
       <div className="mb-6 text-center">
         <div className="flex items-center justify-center mb-2">
           <img

--- a/src/components/sections/ServicesSection.jsx
+++ b/src/components/sections/ServicesSection.jsx
@@ -4,54 +4,65 @@ import { Link } from 'react-router-dom';
 const ServicesSection = () => {
   const services = [
     {
-      title: "Flight Bookings",
-      description: "Find the best flight deals to destinations worldwide with our easy-to-use booking platform.",
-      icon: "✈️",
-      color: "bg-blue-100 text-blue-800"
+      title: 'Flights & Hotels',
+      description: 'Search and book flights and hotels in one place.',
+      iconSrc: '/icons/flyhotel.png',
+      color: 'bg-blue-100',
+      link: '/?service=hotel-flight#booking-widget',
     },
     {
-      title: "Hotel Reservations",
-      description: "Discover accommodations for every budget, from luxury resorts to cozy guesthouses.",
-      icon: "🏨",
-      color: "bg-green-100 text-green-800"
+      title: 'Car Rental',
+      description: 'Find the best rates on car rentals for your trip.',
+      iconSrc: '/icons/carrental.png',
+      color: 'bg-orange-100',
+      link: '/?service=car-rental#booking-widget',
     },
     {
-      title: "Car Rentals",
-      description: "Rent a car for your travels and explore at your own pace with our competitive rates.",
-      icon: "🚗",
-      color: "bg-orange-100 text-orange-800"
+      title: 'Trips',
+      description: 'Discover exciting trips and tours across Morocco.',
+      iconSrc: '/icons/tripsicon.png',
+      color: 'bg-purple-100',
+      link: '/?service=trips#booking-widget',
     },
     {
-      title: "Travel Packages",
-      description: "All-inclusive packages combining flights, hotels, and activities for the perfect vacation.",
-      icon: "🎒",
-      color: "bg-purple-100 text-purple-800"
+      title: 'Pickups',
+      description: 'Arrange hassle-free airport pickups and transfers.',
+      iconSrc: '/icons/pickupsicon.png',
+      color: 'bg-green-100',
+      link: '/?service=pickups#booking-widget',
     },
     {
-      title: "Local Experiences",
-      description: "Book unique tours and activities to truly immerse yourself in local culture.",
-      icon: "🌍",
-      color: "bg-red-100 text-red-800"
+      title: 'eSIM',
+      description: 'Stay connected abroad with affordable eSIM plans.',
+      iconSrc: '/icons/esimicon.png',
+      color: 'bg-yellow-100',
+      link: '/?service=esim#booking-widget',
     },
-    {
-      title: "24/7 Support",
-      description: "Our travel experts are available around the clock to assist with your travel needs.",
-      icon: "📞",
-      color: "bg-yellow-100 text-yellow-800"
-    }
   ];
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
       {services.map((service, index) => (
-        <div key={index} className="bg-white rounded-xl shadow-lg p-6 transition-transform hover:scale-[1.02]">
-          <div className={`${service.color} w-14 h-14 rounded-full flex items-center justify-center text-2xl mb-4`}>
-            {service.icon}
+        <div
+          key={index}
+          className="bg-white rounded-xl shadow-lg p-6 transition-transform hover:scale-[1.02]"
+        >
+          <div
+            className={`${service.color} w-14 h-14 rounded-full flex items-center justify-center mb-4`}
+          >
+            {service.iconSrc ? (
+              <img src={service.iconSrc} alt={service.title} className="w-8 h-8" />
+            ) : (
+              service.icon
+            )}
           </div>
           <h3 className="text-xl font-bold mb-2">{service.title}</h3>
           <p className="text-gray-600 mb-4">{service.description}</p>
-          <Link to="/" className="text-primary font-semibold hover:underline">
-            Learn More
+          <Link
+            to={service.link}
+            className="text-primary font-semibold hover:underline"
+          >
+            Book Now
           </Link>
         </div>
       ))}


### PR DESCRIPTION
## Summary
- list services offered via widgets on the Services page
- link each service card to the proper widget on the home page
- allow selecting a widget using `?service` query parameter
- add anchor id for booking widget

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a26e6b388323aa9e510c4f24e6cd