### PR TITLE
Update layout color and responsive titles

### DIFF
--- a/src/components/booking/BookingWidget.jsx
+++ b/src/components/booking/BookingWidget.jsx
@@ -30,7 +30,7 @@ const BookingWidget = () => {
             alt="Fly and Room Logo"
             className="h-9 mr-2"
           />
-          <h1 className="text-4xl font-bold">
+          <h1 className="text-3xl sm:text-4xl font-bold text-[#272724]">
             <span className="text-[#0c58bb]">Fly</span>
             <span className="text-[#ff5733]">&room.</span>
           </h1>

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -4,13 +4,13 @@ import Footer from './Footer';
 
 const Layout = ({ children }) => {
   return (
-    <div className="relative flex flex-col min-h-screen bg-[#272724]">
+    <div className="relative flex flex-col min-h-screen bg-[#F6F7EA]">
       <Navbar />
       <main className="relative flex-grow py-8">
         {/* Background color only for page content */}
         <div
           aria-hidden="true"
-          className="absolute inset-0 bg-[#272724] pointer-events-none"
+          className="absolute inset-0 bg-[#F6F7EA] pointer-events-none"
         ></div>
         <div className="relative">
           {children}

--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 const HeroSection = () => {
   return (
     <div className="text-center mb-8">
-      <h1 className="text-3xl sm:text-4xl font-bold mb-2">
+      <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-2 text-[#272724]">
         <span className="text-primary">Fly</span> and <span className="text-secondary">room</span>
       </h1>
       <p className="text-gray-600 text-sm sm:text-base kapakana-600">Find and book the best flights and hotels.</p>

--- a/src/pages/ContactPage.jsx
+++ b/src/pages/ContactPage.jsx
@@ -4,7 +4,7 @@ const ContactPage = () => {
   return (
     <div className="container mx-auto px-4 py-12">
       <div className="max-w-3xl mx-auto">
-        <h1 className="text-4xl font-bold mb-6 text-center">
+        <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-6 text-center text-[#272724]">
           Contact <span className="text-primary">Us</span>
         </h1>
         

--- a/src/pages/LocalExpDetailPage.jsx
+++ b/src/pages/LocalExpDetailPage.jsx
@@ -16,7 +16,7 @@ const LocalExpDetailPage = () => {
 
   return (
     <div className="container mx-auto px-4 py-12">
-      <h1 className="text-4xl font-bold mb-4">
+      <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-[#272724]">
         {exp.title}
       </h1>
       <p className="text-gray-700 mb-8">{exp.details}</p>

--- a/src/pages/LocalExpPage.jsx
+++ b/src/pages/LocalExpPage.jsx
@@ -8,7 +8,7 @@ const LocalExpPage = () => {
   return (
     <div className="container mx-auto px-4 py-12">
       <div className="text-center mb-12">
-        <h1 className="text-4xl font-bold mb-4">
+        <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-[#272724]">
           Local <span className="text-primary">Experiences</span> in Morocco
         </h1>
         <p className="text-gray-600 max-w-2xl mx-auto">

--- a/src/pages/PrivacyPolicyPage.jsx
+++ b/src/pages/PrivacyPolicyPage.jsx
@@ -4,7 +4,7 @@ const PrivacyPolicyPage = () => {
   return (
     <div className="container mx-auto px-4 py-12">
       <div className="max-w-3xl mx-auto">
-        <h1 className="text-4xl font-bold mb-6 text-center">
+        <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-6 text-center text-[#272724]">
           Privacy <span className="text-primary">Policy</span>
         </h1>
         

--- a/src/pages/ServicesPage.jsx
+++ b/src/pages/ServicesPage.jsx
@@ -5,7 +5,7 @@ const ServicesPage = () => {
   return (
     <div className="container mx-auto px-4 py-12">
       <div className="text-center mb-12">
-        <h1 className="text-4xl font-bold mb-4">
+        <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-[#272724]">
           Our <span className="text-primary">Services</span>
         </h1>
         <p className="text-gray-600 max-w-2xl mx-auto">


### PR DESCRIPTION
## Summary
- lighten the layout background to `#F6F7EA`
- update heading styles across components and pages to be responsive and match the new color

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b4fe8ba08323a005cad0961573c3