### PR TITLE
Add All in One services section with animation

### DIFF
--- a/src/components/sections/MoroccoSection.jsx
+++ b/src/components/sections/MoroccoSection.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { localExperiences } from '../../data/localExperiences';
+import ServicesSection from './ServicesSection';
 
 const MoroccoSection = () => {
   const previewExperiences = localExperiences.slice(0, 3);
@@ -54,16 +55,23 @@ const MoroccoSection = () => {
               </Link>
             ))}
           </div>
-          <Link
-            to="/local-exp"
-            className="inline-block mt-4 px-6 py-3 bg-primary text-white rounded-lg shadow hover:bg-primary/90"
-          >
-            Explore Local Experiences
-          </Link>
-        </div>
+        <Link
+          to="/local-exp"
+          className="inline-block mt-4 px-6 py-3 bg-primary text-white rounded-lg shadow hover:bg-primary/90"
+        >
+          Explore Local Experiences
+        </Link>
       </div>
-    </section>
-  );
+      <div className="bg-[#272724] rounded-3xl shadow-2xl p-8 text-center text-white">
+        <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-4 text-center">All in One</h2>
+        <p className="text-xl max-w-3xl mx-auto text-gray-300 mb-6">
+          Browse all of our travel services in a single place and start planning your adventure today.
+        </p>
+        <ServicesSection />
+      </div>
+    </div>
+  </section>
+);
 };
 
 export default MoroccoSection;

--- a/src/components/sections/ServicesSection.jsx
+++ b/src/components/sections/ServicesSection.jsx
@@ -43,9 +43,10 @@ const ServicesSection = () => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
       {services.map((service, index) => (
-        <div
+        <Link
           key={index}
-          className="bg-white rounded-xl shadow-lg p-6 transition-transform hover:scale-[1.02]"
+          to={service.link}
+          className="bg-white rounded-xl shadow-lg p-6 transition-transform hover:scale-[1.02] animate-slide-left"
         >
           <div
             className={`${service.color} w-14 h-14 rounded-full flex items-center justify-center mb-4`}
@@ -58,13 +59,8 @@ const ServicesSection = () => {
           </div>
           <h3 className="text-xl font-bold mb-2">{service.title}</h3>
           <p className="text-gray-600 mb-4">{service.description}</p>
-          <Link
-            to={service.link}
-            className="text-primary font-semibold hover:underline"
-          >
-            Book Now
-          </Link>
-        </div>
+          <span className="text-primary font-semibold hover:underline">Book Now</span>
+        </Link>
       ))}
     </div>
   );

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -9,7 +9,16 @@ module.exports = {
         primary: '#0c58bb', // Keeping your blue
         secondary: '#ff5733', // Keeping your orange
         navbg: '#1F2937', // Adding new navbar color
-      }
+      },
+      keyframes: {
+        'slide-left': {
+          '0%': { transform: 'translateX(50px)', opacity: '0' },
+          '100%': { transform: 'translateX(0)', opacity: '1' },
+        },
+      },
+      animation: {
+        'slide-left': 'slide-left 1s ease-in-out',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- include slide-left animation in Tailwind config
- make `ServicesSection` cards clickable and animated
- show service cards on the home page under a new **All in One** card

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d8bf05888323902b9884048a835e