### PR TITLE
Animate All-in-One service cards

### DIFF
--- a/src/components/sections/ServicesSection.jsx
+++ b/src/components/sections/ServicesSection.jsx
@@ -40,14 +40,17 @@ const ServicesSection = () => {
     },
   ];
 
+  const scrollingServices = [...services, ...services];
+
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-      {services.map((service, index) => (
-        <Link
-          key={index}
-          to={service.link}
-          className="bg-white rounded-xl shadow-lg p-6 transition-transform hover:scale-[1.02] animate-slide-left"
-        >
+    <div className="overflow-hidden">
+      <div className="flex w-max space-x-8 animate-marquee">
+        {scrollingServices.map((service, index) => (
+          <Link
+            key={index}
+            to={service.link}
+            className="bg-white rounded-xl shadow-lg p-6 transition-transform hover:scale-[1.02]"
+          >
           <div
             className={`${service.color} w-14 h-14 rounded-full flex items-center justify-center mb-4`}
           >
@@ -59,9 +62,10 @@ const ServicesSection = () => {
           </div>
           <h3 className="text-xl font-bold mb-2">{service.title}</h3>
           <p className="text-gray-600 mb-4">{service.description}</p>
-          <span className="text-primary font-semibold hover:underline">Book Now</span>
-        </Link>
-      ))}
+            <span className="text-primary font-semibold hover:underline">Book Now</span>
+          </Link>
+        ))}
+      </div>
     </div>
   );
 };

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -15,9 +15,14 @@ module.exports = {
           '0%': { transform: 'translateX(50px)', opacity: '0' },
           '100%': { transform: 'translateX(0)', opacity: '1' },
         },
+        marquee: {
+          '0%': { transform: 'translateX(0)' },
+          '100%': { transform: 'translateX(-50%)' },
+        },
       },
       animation: {
         'slide-left': 'slide-left 1s ease-in-out',
+        marquee: 'marquee 20s linear infinite',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add marquee animation to Tailwind config
- scroll service cards continuously

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855dabb1c088323bfd309069cec5b93