### PR TITLE
Improve service card scroll behavior

### DIFF
--- a/src/components/sections/ServicesSection.jsx
+++ b/src/components/sections/ServicesSection.jsx
@@ -49,6 +49,14 @@ const ServicesSection = () => {
           <Link
             key={index}
             to={service.link}
+            onClick={() => {
+              const el = document.getElementById('booking-widget');
+              if (el) {
+                el.scrollIntoView({ behavior: 'smooth' });
+              } else {
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+              }
+            }}
             className="bg-white rounded-xl shadow-lg p-6 transition-transform hover:scale-[1.02]"
           >
           <div

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -22,7 +22,7 @@ module.exports = {
       },
       animation: {
         'slide-left': 'slide-left 1s ease-in-out',
-        marquee: 'marquee 20s linear infinite',
+        marquee: 'marquee 30s linear infinite',
       },
     },
   },


### PR DESCRIPTION
## Summary
- smooth scroll to the booking widget when clicking a service card
- slow the marquee animation so cards scroll more gently

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855dcbb73988323b3ffae3d3e6dc666