### PR TITLE
Make navbar logo scroll to top

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -14,7 +14,13 @@ const Navbar = () => {
   return (
     <nav className="bg-white text-gray-800 py-2 shadow-md border-b border-gray-200 sticky top-0 z-50">
       <div className="w-full px-2 md:px-4 flex items-center justify-center md:justify-start relative">
-        <Link to="/">
+        <Link
+          to="/"
+          onClick={() => {
+            setMobileMenuOpen(false);
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+          }}
+        >
           <img
             src="/logos/mainlogo.png"
             alt="Fly and Room Logo"


### PR DESCRIPTION
## Summary
- keep mobile menu closed when clicking the logo
- scroll to the top of the page on logo click

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855f7192be48323bdadcd5ac97f20d3