### PR TITLE
Improve widget loading responsiveness

### DIFF
--- a/src/components/booking/BookingWidget.jsx
+++ b/src/components/booking/BookingWidget.jsx
@@ -98,11 +98,21 @@ const BookingWidget = () => {
         </button>
       </div>
       <div className="widget-container min-h-[300px]">
-        {activeWidget === 'hotel-flight' && <HotelFlightWidget />}
-        {activeWidget === 'car-rental' && <CarRentalWidget />}
-        {activeWidget === 'trips' && <TripsWidget />}
-        {activeWidget === 'pickups' && <PickupsWidget />}
-        {activeWidget === 'esim' && <EsimWidget />}
+        <div className={activeWidget === 'hotel-flight' ? '' : 'hidden'}>
+          <HotelFlightWidget />
+        </div>
+        <div className={activeWidget === 'car-rental' ? '' : 'hidden'}>
+          <CarRentalWidget />
+        </div>
+        <div className={activeWidget === 'trips' ? '' : 'hidden'}>
+          <TripsWidget />
+        </div>
+        <div className={activeWidget === 'pickups' ? '' : 'hidden'}>
+          <PickupsWidget />
+        </div>
+        <div className={activeWidget === 'esim' ? '' : 'hidden'}>
+          <EsimWidget />
+        </div>
       </div>
     </div>
   );

--- a/src/components/booking/CarRentalWidget.jsx
+++ b/src/components/booking/CarRentalWidget.jsx
@@ -1,22 +1,22 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 const CarRentalWidget = () => {
+  const loaded = useRef(false);
+
   useEffect(() => {
+    if (loaded.current) return;
+
     const script = document.createElement('script');
-    script.src = "https://c87.travelpayouts.com/content?trs=425059&shmarker=636307.636307&powered_by=true&country=99&city=461&lang=en&width=100&background=light&logo=true&header=true&gearbox=false&cars=false&border=false&footer=true&promo_id=4322";
+    script.src =
+      "https://c87.travelpayouts.com/content?trs=425059&shmarker=636307.636307&powered_by=true&country=99&city=461&lang=en&width=100&background=light&logo=true&header=true&gearbox=false&cars=false&border=false&footer=true&promo_id=4322";
     script.async = true;
     script.charset = 'utf-8';
-    
+
     const container = document.getElementById('car-rental-widget-container');
     if (container) {
       container.appendChild(script);
+      loaded.current = true;
     }
-
-    return () => {
-      if (container && script.parentNode === container) {
-        container.removeChild(script);
-      }
-    };
   }, []);
 
   return <div id="car-rental-widget-container" className="w-full shadow-lg"></div>;

--- a/src/components/booking/EsimWidget.jsx
+++ b/src/components/booking/EsimWidget.jsx
@@ -1,22 +1,22 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 const EsimWidget = () => {
+  const loaded = useRef(false);
+
   useEffect(() => {
+    if (loaded.current) return;
+
     const script = document.createElement('script');
-    script.src = 'https://tpwidg.com/content?trs=425059&shmarker=636307.636307&locale=en&powered_by=true&color_button=%23ff5733&color_focused=%23f2685f&secondary=%23FFFFFF&dark=%2311100f&light=%23FFFFFF&special=%23000000ff&border_radius=5&plain=false&no_labels=true&promo_id=8588&campaign_id=541';
+    script.src =
+      'https://tpwidg.com/content?trs=425059&shmarker=636307.636307&locale=en&powered_by=true&color_button=%23ff5733&color_focused=%23f2685f&secondary=%23FFFFFF&dark=%2311100f&light=%23FFFFFF&special=%23000000ff&border_radius=5&plain=false&no_labels=true&promo_id=8588&campaign_id=541';
     script.async = true;
     script.charset = 'utf-8';
 
     const container = document.getElementById('esim-widget-container');
     if (container) {
       container.appendChild(script);
+      loaded.current = true;
     }
-
-    return () => {
-      if (container && script.parentNode === container) {
-        container.removeChild(script);
-      }
-    };
   }, []);
 
   return <div id="esim-widget-container" className="w-full shadow-lg"></div>;

--- a/src/components/booking/HotelFlightWidget.jsx
+++ b/src/components/booking/HotelFlightWidget.jsx
@@ -1,22 +1,22 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 const HotelFlightWidget = () => {
+  const loaded = useRef(false);
+
   useEffect(() => {
+    if (loaded.current) return;
+
     const script = document.createElement('script');
-    script.src = "https://tpwidg.com/content?trs=425059&shmarker=636307.636307&locale=en&curr=USD&powered_by=true&border_radius=0&plain=false&color_button=%230c58bb&color_button_text=%23ffffff&color_border=%230c58bb&promo_id=4132&campaign_id=121";
+    script.src =
+      "https://tpwidg.com/content?trs=425059&shmarker=636307.636307&locale=en&curr=USD&powered_by=true&border_radius=0&plain=false&color_button=%230c58bb&color_button_text=%23ffffff&color_border=%230c58bb&promo_id=4132&campaign_id=121";
     script.async = true;
     script.charset = 'utf-8';
-    
+
     const container = document.getElementById('hotel-flight-widget-container');
     if (container) {
       container.appendChild(script);
+      loaded.current = true;
     }
-
-    return () => {
-      if (container && script.parentNode === container) {
-        container.removeChild(script);
-      }
-    };
   }, []);
 
   return <div id="hotel-flight-widget-container" className="w-full shadow-lg"></div>;

--- a/src/components/booking/PickupsWidget.jsx
+++ b/src/components/booking/PickupsWidget.jsx
@@ -1,22 +1,22 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 const PickupsWidget = () => {
+  const loaded = useRef(false);
+
   useEffect(() => {
+    if (loaded.current) return;
+
     const script = document.createElement('script');
-    script.src = 'https://tpwidg.com/content?trs=425059&shmarker=636307.636307&locale=en&show_header=true&powered_by=true&campaign_id=627&promo_id=8951';
+    script.src =
+      'https://tpwidg.com/content?trs=425059&shmarker=636307.636307&locale=en&show_header=true&powered_by=true&campaign_id=627&promo_id=8951';
     script.async = true;
     script.charset = 'utf-8';
 
     const container = document.getElementById('pickups-widget-container');
     if (container) {
       container.appendChild(script);
+      loaded.current = true;
     }
-
-    return () => {
-      if (container && script.parentNode === container) {
-        container.removeChild(script);
-      }
-    };
   }, []);
 
   return <div id="pickups-widget-container" className="w-full shadow-lg"></div>;

--- a/src/components/booking/TripsWidget.jsx
+++ b/src/components/booking/TripsWidget.jsx
@@ -1,7 +1,11 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 const TripsWidget = () => {
+  const loaded = useRef(false);
+
   useEffect(() => {
+    if (loaded.current) return;
+
     const container = document.getElementById('trips-widget-container');
     if (!container) return;
 
@@ -12,10 +16,7 @@ const TripsWidget = () => {
     script.charset = 'utf-8';
 
     container.appendChild(script);
-
-    return () => {
-      container.innerHTML = '';
-    };
+    loaded.current = true;
   }, []);
 
   return <div id="trips-widget-container" className="w-full shadow-lg"></div>;


### PR DESCRIPTION
## Summary
- keep booking widgets mounted instead of reloading each switch
- load each booking widget script only once to speed up switching

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68560514b5908323aba4c1a2200adb94