### PR TITLE
Move partner logos into standalone section

### DIFF
--- a/src/components/sections/MoroccoSection.jsx
+++ b/src/components/sections/MoroccoSection.jsx
@@ -69,31 +69,6 @@ const MoroccoSection = () => {
         </p>
         <ServicesSection />
       </div>
-      <div className="bg-[#F6F7EA] shadow-2xl p-8 text-center w-screen relative left-1/2 right-1/2 ml-[-50vw] mr-[-50vw]">
-        <h3 className="text-xl sm:text-2xl md:text-3xl font-bold mb-4 text-[#272724]">Our Partners</h3>
-        <div className="flex flex-wrap justify-center items-center gap-4 sm:gap-6">
-          <img
-            src="/icons/esimparicon.png"
-            alt="eSIM partner"
-            className="h-16 sm:h-20 md:h-24 w-auto"
-          />
-          <img
-            src="/icons/localrenticonpar.png"
-            alt="LocalRent partner"
-            className="h-16 sm:h-20 md:h-24 w-auto"
-          />
-          <img
-            src="/icons/pickupsparicon.png"
-            alt="Pickups partner"
-            className="h-16 sm:h-20 md:h-24 w-auto"
-          />
-          <img
-            src="/icons/tripiconpar.png"
-            alt="Trip partner"
-            className="h-16 sm:h-20 md:h-24 w-auto"
-          />
-        </div>
-      </div>
     </div>
   </section>
 );

--- a/src/components/sections/PartnersSection.jsx
+++ b/src/components/sections/PartnersSection.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const PartnersSection = () => (
+  <div className="container mx-auto px-4 my-8">
+    <h3 className="text-xl sm:text-2xl md:text-3xl font-bold mb-4 text-center text-[#272724]">
+      Our Partners
+    </h3>
+    <div className="flex flex-wrap justify-center items-center gap-4 sm:gap-6">
+      <img
+        src="/icons/esimparicon.png"
+        alt="eSIM partner"
+        className="h-16 sm:h-20 md:h-24 w-auto"
+      />
+      <img
+        src="/icons/localrenticonpar.png"
+        alt="LocalRent partner"
+        className="h-16 sm:h-20 md:h-24 w-auto"
+      />
+      <img
+        src="/icons/pickupsparicon.png"
+        alt="Pickups partner"
+        className="h-16 sm:h-20 md:h-24 w-auto"
+      />
+      <img
+        src="/icons/tripiconpar.png"
+        alt="Trip partner"
+        className="h-16 sm:h-20 md:h-24 w-auto"
+      />
+    </div>
+  </div>
+);
+
+export default PartnersSection;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import BookingWidget from '../components/booking/BookingWidget';
 import MoroccoSection from '../components/sections/MoroccoSection';
+import PartnersSection from '../components/sections/PartnersSection';
 
 const HomePage = () => {
   return (
@@ -9,6 +10,7 @@ const HomePage = () => {
         <BookingWidget />
       </div>
       <MoroccoSection />
+      <PartnersSection />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- relocate partner logos from `MoroccoSection` to a new `PartnersSection`
- show `PartnersSection` on the home page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856c1d3e85883238ccda2b22eddde68