### PR TITLE
Remove Fly&Room text from widget and footer

### DIFF
--- a/src/components/booking/BookingWidget.jsx
+++ b/src/components/booking/BookingWidget.jsx
@@ -29,12 +29,8 @@ const BookingWidget = () => {
           <img
             src="/logos/newlogoo.png"
             alt="Fly and Room Logo"
-            className="h-10 sm:h-12 md:h-14 w-auto mr-2"
+            className="h-20 sm:h-24 md:h-32 w-auto"
           />
-          <h1 className="text-3xl sm:text-4xl font-bold text-[#272724]">
-            <span className="text-[#0c58bb]">Fly</span>
-            <span className="text-[#ff5733]">&room.</span>
-          </h1>
         </div>
         <p className="text-gray-600 kapakana-450">Let Morocco Shift Your Soul.</p>
       </div>

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -19,13 +19,8 @@ const Footer = () => {
   <img
     src="/logos/newlogoo.png"
     alt="Fly and Room Logo"
-    className="h-10 sm:h-12 md:h-14 w-auto mr-3"
+    className="h-16 sm:h-20 md:h-24 w-auto"
   />
-  <span className="text-xl font-bold hover:no-underline">
-    <span className="text-primary">Fly</span>{' '}
-    and{' '}
-    <span className="text-secondary">room.</span>
-  </span>
 </Link>
               <p className="mt-2 text-gray-600 max-w-md text-sm md:text-base">
               Your trusted partner for flights, hotels, and car rentals in Morocco and beyond.


### PR DESCRIPTION
## Summary
- remove Fly&Room text from booking widget heading
- enlarge booking widget logo
- remove Fly&Room text next to footer logo and enlarge

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856d102a52483239ce3a37e0e830098