### PR TITLE
Fix navbar logo centering on mobile

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -20,6 +20,7 @@ const Navbar = () => {
             setMobileMenuOpen(false);
             window.scrollTo({ top: 0, behavior: 'smooth' });
           }}
+          className="absolute left-1/2 -translate-x-1/2 md:static md:transform-none"
         >
           <img
             src="/logos/newlogoo.png"


### PR DESCRIPTION
## Summary
- ensure navbar logo is centered on small screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856d69149a0832396aada571ce1a6a2