### PR TITLE
Fix logo layout in mobile navbar

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -20,7 +20,6 @@ const Navbar = () => {
             setMobileMenuOpen(false);
             window.scrollTo({ top: 0, behavior: 'smooth' });
           }}
-          className="absolute left-1/2 -translate-x-1/2 md:static md:transform-none"
         >
           <img
             src="/logos/newlogoo.png"


### PR DESCRIPTION
## Summary
- remove absolute centering class from the logo link in Navbar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856d919b7088323b805e9f18feaa155