### PR TITLE
Update BookingWidget slogan font

### DIFF
--- a/src/components/booking/BookingWidget.jsx
+++ b/src/components/booking/BookingWidget.jsx
@@ -26,7 +26,7 @@ const BookingWidget = () => {
     >
       <div className="mb-6 text-center">
         <p
-          className="kapakana-600 font-bold text-2xl sm:text-3xl md:text-4xl"
+          className="text-2xl sm:text-3xl md:text-4xl"
           style={{ color: '#272724' }}
         >
           All in One Place for Your Next Journey.


### PR DESCRIPTION
## Summary
- use the default font for the slogan inside `BookingWidget`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856dd0c1e508323bc32e36bf0820f9c