### PR TITLE
Add hotel detail pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import PrivacyPolicyPage from './pages/PrivacyPolicyPage';
 import LocalExpPage from './pages/LocalExpPage';
 import LocalExpDetailPage from './pages/LocalExpDetailPage';
 import BestHotelsPage from './pages/BestHotelsPage';
+import HotelDetailPage from './pages/HotelDetailPage';
 
 function App() {
   return (
@@ -23,6 +24,7 @@ function App() {
             <Route path="/contact" element={<ContactPage />} />
             <Route path="/privacy" element={<PrivacyPolicyPage />} />
             <Route path="/best-hotels" element={<BestHotelsPage />} />
+            <Route path="/best-hotels/:slug" element={<HotelDetailPage />} />
             <Route path="/local-exp" element={<LocalExpPage />} />
             <Route path="/local-exp/:slug" element={<LocalExpDetailPage />} />
           </Routes>

--- a/src/pages/BestHotelsPage.jsx
+++ b/src/pages/BestHotelsPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { bestHotels } from '../data/bestHotels';
 
 const BestHotelsPage = () => {
@@ -17,8 +18,9 @@ const BestHotelsPage = () => {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
         {hotels.map((hotel, index) => (
-          <div
+          <Link
             key={index}
+            to={`/best-hotels/${hotel.slug}`}
             className="bg-white rounded-xl overflow-hidden shadow-lg transition-transform hover:scale-[1.02]"
           >
             <img
@@ -29,9 +31,9 @@ const BestHotelsPage = () => {
             <div className="p-6">
               <h3 className="text-xl font-bold mb-2">{hotel.title}</h3>
               <p className="text-gray-600 mb-4">{hotel.description}</p>
-              <span className="text-primary font-semibold">Discover Hotel</span>
+              <span className="text-primary font-semibold hover:underline">Discover Hotel</span>
             </div>
-          </div>
+          </Link>
         ))}
       </div>
     </div>

--- a/src/pages/HotelDetailPage.jsx
+++ b/src/pages/HotelDetailPage.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { bestHotels } from '../data/bestHotels';
+
+const HotelDetailPage = () => {
+  const { slug } = useParams();
+  const hotel = bestHotels.find((h) => h.slug === slug);
+
+  if (!hotel) {
+    return (
+      <div className="container mx-auto px-4 py-12">
+        <p className="text-center text-gray-600">Hotel not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-[#272724]">
+        {hotel.title}
+      </h1>
+      <p className="text-gray-700 mb-8">{hotel.details}</p>
+      <Link to="/best-hotels" className="text-primary font-semibold hover:underline">
+        &larr; Back to hotels
+      </Link>
+    </div>
+  );
+};
+
+export default HotelDetailPage;


### PR DESCRIPTION
## Summary
- make best hotel cards clickable
- show hotel detail page
- wire up `/best-hotels/:slug` route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856e16c33e883239ec135727953e11a