### PR TITLE
Fix Hilton link target

### DIFF
--- a/src/data/bestHotels.jsx
+++ b/src/data/bestHotels.jsx
@@ -85,6 +85,8 @@ export const bestHotels = [
           <a
             href="https://www3.hilton.com/en/hotels/morocco/hilton-tangier-al-houara-resort-and-spa-TNGAHHI/index.html"
             className="text-primary underline"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             Book at Hilton Al Houara
           </a>


### PR DESCRIPTION
## Summary
- make the booking link in Tanger-Hilton Al Houara card open in a new tab

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6858198ebbd08323a1cc614eaf3318e1