### PR TITLE
Add map widget for Stayhere Rabat

### DIFF
--- a/src/data/bestHotels.jsx
+++ b/src/data/bestHotels.jsx
@@ -372,6 +372,17 @@ export const bestHotels = [
         >
           Check Availability &amp; Book Now
         </a>
+
+        <div className="mt-8">
+          <iframe
+            title="Stayhere Rabat - Agdal 4 Hotel Map"
+            src="https://www.google.com/maps?q=X5W2%2BQW%20Rabat&output=embed"
+            width="100%"
+            height="300"
+            className="w-full rounded-lg"
+            allowFullScreen
+          ></iframe>
+        </div>
       </section>
     ),
     image: '/images/stayhere.jpg',


### PR DESCRIPTION
## Summary
- embed Google map for Stayhere Rabat - Agdal 4 Hotel

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6858320fc8748323ba4eb649652f364c