### PR TITLE
Fix mobile navbar logo alignment

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -14,7 +14,7 @@ const Navbar = () => {
 
   return (
     <nav className="bg-white text-gray-800 py-1 shadow-md border-b border-gray-200 sticky top-0 z-50">
-      <div className="w-full px-2 md:px-4 flex items-center justify-center md:justify-start relative">
+      <div className="w-full px-2 md:px-4 flex items-center justify-start relative">
         <Link
           to="/"
           onClick={() => {


### PR DESCRIPTION
## Summary
- adjust mobile navbar layout to left-align the logo

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68597772a3788323a387b8df07d09b4b