### PR TITLE
Slow slide effect for Exclusive Hotels

### DIFF
--- a/src/components/sections/MoroccoSection.jsx
+++ b/src/components/sections/MoroccoSection.jsx
@@ -17,7 +17,11 @@ const MoroccoSection = () => {
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
             {previewHotels.map((hotel, index) => (
-              <HotelCard key={index} hotel={hotel} animation="animate-slide-left" />
+              <HotelCard
+                key={index}
+                hotel={hotel}
+                animation="animate-slide-left-slow"
+              />
             ))}
           </div>
           <Link

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -22,6 +22,7 @@ module.exports = {
       },
       animation: {
         'slide-left': 'slide-left 1s ease-in-out',
+        'slide-left-slow': 'slide-left 5s ease-in-out',
         marquee: 'marquee 30s linear infinite',
       },
     },


### PR DESCRIPTION
## Summary
- create `slide-left-slow` animation in Tailwind
- apply slow slide animation to Exclusive Hotels cards on the home page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68598e95d54c8323a651b0459d0266de