### PR TITLE
Fix slow loading booking widget

### DIFF
--- a/src/components/booking/BookingWidget.jsx
+++ b/src/components/booking/BookingWidget.jsx
@@ -13,11 +13,11 @@ const BookingWidget = () => {
 
   useEffect(() => {
     const service = searchParams.get('service');
-    if (service) {
+    if (service && service !== activeWidget) {
       switchWidget(service);
     }
     // Only run this effect when the query parameter changes
-  }, [searchParams]);
+  }, [searchParams, activeWidget, switchWidget]);
 
   return (
     <div

--- a/src/components/booking/CarRentalWidget.jsx
+++ b/src/components/booking/CarRentalWidget.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useRef } from 'react';
+import { useWidget } from '../../context/WidgetContext';
 
 const CarRentalWidget = () => {
+  const { activeWidget } = useWidget();
   const loaded = useRef(false);
 
   useEffect(() => {
-    if (loaded.current) return;
+    if (activeWidget !== 'car-rental' || loaded.current) return;
 
     const script = document.createElement('script');
     script.src =
@@ -17,9 +19,9 @@ const CarRentalWidget = () => {
       container.appendChild(script);
       loaded.current = true;
     }
-  }, []);
+  }, [activeWidget]);
 
   return <div id="car-rental-widget-container" className="w-full shadow-lg"></div>;
 };
 
-export default CarRentalWidget;
+export default CarRentalWidget

--- a/src/components/booking/EsimWidget.jsx
+++ b/src/components/booking/EsimWidget.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useRef } from 'react';
+import { useWidget } from '../../context/WidgetContext';
 
 const EsimWidget = () => {
+  const { activeWidget } = useWidget();
   const loaded = useRef(false);
 
   useEffect(() => {
-    if (loaded.current) return;
+    if (activeWidget !== 'esim' || loaded.current) return;
 
     const script = document.createElement('script');
     script.src =
@@ -17,7 +19,7 @@ const EsimWidget = () => {
       container.appendChild(script);
       loaded.current = true;
     }
-  }, []);
+  }, [activeWidget]);
 
   return <div id="esim-widget-container" className="w-full shadow-lg"></div>;
 };

--- a/src/components/booking/HotelFlightWidget.jsx
+++ b/src/components/booking/HotelFlightWidget.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useRef } from 'react';
+import { useWidget } from '../../context/WidgetContext';
 
 const HotelFlightWidget = () => {
+  const { activeWidget } = useWidget();
   const loaded = useRef(false);
 
   useEffect(() => {
-    if (loaded.current) return;
+    if (activeWidget !== 'hotel-flight' || loaded.current) return;
 
     const script = document.createElement('script');
     script.src =
@@ -17,9 +19,9 @@ const HotelFlightWidget = () => {
       container.appendChild(script);
       loaded.current = true;
     }
-  }, []);
+  }, [activeWidget]);
 
   return <div id="hotel-flight-widget-container" className="w-full shadow-lg"></div>;
 };
 
-export default HotelFlightWidget;
+export default HotelFlightWidget

--- a/src/components/booking/PickupsWidget.jsx
+++ b/src/components/booking/PickupsWidget.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useRef } from 'react';
+import { useWidget } from '../../context/WidgetContext';
 
 const PickupsWidget = () => {
+  const { activeWidget } = useWidget();
   const loaded = useRef(false);
 
   useEffect(() => {
-    if (loaded.current) return;
+    if (activeWidget !== 'pickups' || loaded.current) return;
 
     const script = document.createElement('script');
     script.src =
@@ -17,7 +19,7 @@ const PickupsWidget = () => {
       container.appendChild(script);
       loaded.current = true;
     }
-  }, []);
+  }, [activeWidget]);
 
   return <div id="pickups-widget-container" className="w-full shadow-lg"></div>;
 };

--- a/src/components/booking/TripsWidget.jsx
+++ b/src/components/booking/TripsWidget.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useRef } from 'react';
+import { useWidget } from '../../context/WidgetContext';
 
 const TripsWidget = () => {
+  const { activeWidget } = useWidget();
   const loaded = useRef(false);
 
   useEffect(() => {
-    if (loaded.current) return;
+    if (activeWidget !== 'trips' || loaded.current) return;
 
     const container = document.getElementById('trips-widget-container');
     if (!container) return;
@@ -17,7 +19,7 @@ const TripsWidget = () => {
 
     container.appendChild(script);
     loaded.current = true;
-  }, []);
+  }, [activeWidget]);
 
   return <div id="trips-widget-container" className="w-full shadow-lg"></div>;
 };

--- a/src/context/WidgetContext.jsx
+++ b/src/context/WidgetContext.jsx
@@ -2,8 +2,13 @@ import React, { createContext, useState, useContext } from 'react';
 
 const WidgetContext = createContext();
 
+const getDefaultWidget = () => {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('service') || 'hotel-flight';
+};
+
 export const WidgetProvider = ({ children }) => {
-  const [activeWidget, setActiveWidget] = useState('hotel-flight');
+  const [activeWidget, setActiveWidget] = useState(getDefaultWidget());
 
   const switchWidget = (widgetType) => {
     setActiveWidget(widgetType);
@@ -17,3 +22,4 @@ export const WidgetProvider = ({ children }) => {
 };
 
 export const useWidget = () => useContext(WidgetContext);
+


### PR DESCRIPTION
## Summary
- lazily load booking widget scripts when each section is opened
- read initial widget from `service` query param

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859dfa64ddc83238ff37fd84a042246