### PR TITLE
Fix home page lag by lazy loading images

### DIFF
--- a/src/components/HotelCard.jsx
+++ b/src/components/HotelCard.jsx
@@ -7,7 +7,12 @@ const HotelCard = ({ hotel, animation = '' }) => {
       to={`/best-hotels/${hotel.slug}`}
       className={`bg-white rounded-xl overflow-hidden shadow-lg transition-transform hover:scale-[1.02] ${animation}`}
     >
-      <img src={hotel.image} alt={hotel.title} className="h-48 w-full object-cover" />
+      <img
+        src={hotel.image}
+        alt={hotel.title}
+        className="h-48 w-full object-cover"
+        loading="lazy"
+      />
       <div className="p-6">
         <h3 className="text-xl font-bold mb-2">{hotel.title}</h3>
         <p className="text-gray-600 mb-4">{hotel.description}</p>

--- a/src/components/MarrakechTourDetails.jsx
+++ b/src/components/MarrakechTourDetails.jsx
@@ -27,6 +27,7 @@ const MarrakechTourDetails = () => {
               src={img.src}
               alt={img.alt}
               className="mt-2 w-full h-40 object-cover rounded cursor-pointer"
+              loading="lazy"
               onClick={() => setOpenImage(img.src)}
             />
           </div>
@@ -43,7 +44,12 @@ const MarrakechTourDetails = () => {
           className="fixed inset-0 flex items-center justify-center bg-black/70 z-50"
           onClick={() => setOpenImage(null)}
         >
-          <img src={openImage} alt="Preview" className="max-h-full max-w-full rounded" />
+          <img
+            src={openImage}
+            alt="Preview"
+            className="max-h-full max-w-full rounded"
+            loading="lazy"
+          />
         </div>
       )}
     </div>

--- a/src/components/booking/BookingWidget.jsx
+++ b/src/components/booking/BookingWidget.jsx
@@ -43,7 +43,12 @@ const BookingWidget = () => {
           onClick={() => switchWidget('hotel-flight')}
         >
           {/* Updated icon size from w-6 h-6 to w-8 h-8 */}
-          <img src="/icons/newflighticon.png" alt="Flights & Hotels" className="w-8 h-8 mr-2" />
+          <img
+            src="/icons/newflighticon.png"
+            alt="Flights & Hotels"
+            className="w-8 h-8 mr-2"
+            loading="lazy"
+          />
           Flights & Hotels
         </button>
         <button
@@ -54,7 +59,12 @@ const BookingWidget = () => {
           }`}
           onClick={() => switchWidget('car-rental')}
         >
-          <img src="/icons/newcarrentalicon.png" alt="Car Rental" className="w-8 h-8 mr-2" />
+          <img
+            src="/icons/newcarrentalicon.png"
+            alt="Car Rental"
+            className="w-8 h-8 mr-2"
+            loading="lazy"
+          />
           Car Rental
         </button>
         <button
@@ -65,7 +75,12 @@ const BookingWidget = () => {
           }`}
           onClick={() => switchWidget('trips')}
         >
-          <img src="/icons/tripsicon.png" alt="Trips" className="w-8 h-8 mr-2" />
+          <img
+            src="/icons/tripsicon.png"
+            alt="Trips"
+            className="w-8 h-8 mr-2"
+            loading="lazy"
+          />
           Trips
         </button>
         <button
@@ -76,7 +91,12 @@ const BookingWidget = () => {
           }`}
           onClick={() => switchWidget('pickups')}
         >
-          <img src="/icons/pickupsicon.png" alt="Pickups" className="w-8 h-8 mr-2" />
+          <img
+            src="/icons/pickupsicon.png"
+            alt="Pickups"
+            className="w-8 h-8 mr-2"
+            loading="lazy"
+          />
           Pickups
         </button>
         <button
@@ -87,7 +107,12 @@ const BookingWidget = () => {
           }`}
           onClick={() => switchWidget('esim')}
         >
-          <img src="/icons/esimicon.png" alt="eSIM" className="w-8 h-8 mr-2" />
+          <img
+            src="/icons/esimicon.png"
+            alt="eSIM"
+            className="w-8 h-8 mr-2"
+            loading="lazy"
+          />
           eSIM
         </button>
       </div>

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -21,6 +21,7 @@ const Footer = () => {
     src="/logos/newlogoo.png"
     alt="Fly and Room Logo"
     className="h-16 sm:h-20 md:h-24 w-auto"
+    loading="lazy"
   />
 </Link>
               <p className="mt-2 text-gray-600 max-w-md text-sm md:text-base">

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -26,6 +26,7 @@ const Navbar = () => {
             src="/logos/newlogoo.png"
             alt="Fly and Room Logo"
             className="h-12 md:h-16 transform scale-125 origin-left"
+            loading="lazy"
           />
         </Link>
         

--- a/src/components/sections/MoroccoSection.jsx
+++ b/src/components/sections/MoroccoSection.jsx
@@ -33,7 +33,12 @@ const MoroccoSection = () => {
           <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-4 text-center">
             Places for Tourists
             <span className="inline-flex items-center">
-              <img src="/icons/moroccoflag.png" alt="Morocco flag" className="w-6 h-6 ml-2 inline-block" />
+              <img
+                src="/icons/moroccoflag.png"
+                alt="Morocco flag"
+                className="w-6 h-6 ml-2 inline-block"
+                loading="lazy"
+              />
             </span>
           </h2>
           <p className="text-xl max-w-3xl mx-auto text-gray-700">
@@ -50,6 +55,7 @@ const MoroccoSection = () => {
                   src={exp.image ? exp.image : `/localexp/${exp.slug}.svg`}
                   alt={exp.title}
                   className="h-32 w-full object-cover"
+                  loading="lazy"
                 />
                 <div className="p-4">
                   <h3 className="text-lg font-bold mb-2">{exp.title}</h3>

--- a/src/components/sections/ServicesSection.jsx
+++ b/src/components/sections/ServicesSection.jsx
@@ -76,7 +76,12 @@ const ServicesSection = ({ animate = true }) => {
             className={`${service.color} w-14 h-14 rounded-full flex items-center justify-center mb-4`}
           >
             {service.iconSrc ? (
-              <img src={service.iconSrc} alt={service.title} className="w-8 h-8" />
+              <img
+                src={service.iconSrc}
+                alt={service.title}
+                className="w-8 h-8"
+                loading="lazy"
+              />
             ) : (
               service.icon
             )}

--- a/src/pages/HotelDetailPage.jsx
+++ b/src/pages/HotelDetailPage.jsx
@@ -34,6 +34,7 @@ const HotelDetailPage = () => {
                   src={src}
                   alt={`${hotel.title} ${idx + 1}`}
                   className="w-full h-40 object-cover cursor-pointer"
+                  loading="lazy"
                 />
               </button>
             ))}
@@ -43,7 +44,12 @@ const HotelDetailPage = () => {
               className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75"
               onClick={() => setSelectedImage(null)}
             >
-              <img src={selectedImage} alt="Selected" className="max-h-full max-w-full" />
+              <img
+                src={selectedImage}
+                alt="Selected"
+                className="max-h-full max-w-full"
+                loading="lazy"
+              />
             </div>
           )}
         </>

--- a/src/pages/LocalExpPage.jsx
+++ b/src/pages/LocalExpPage.jsx
@@ -28,6 +28,7 @@ const LocalExpPage = () => {
               src={exp.image ? exp.image : `/localexp/${exp.slug}.svg`}
               alt={exp.title}
               className="h-48 w-full object-cover"
+              loading="lazy"
             />
             <div className="p-6">
               <h3 className="text-xl font-bold mb-2">{exp.title}</h3>


### PR DESCRIPTION
## Summary
- enable `loading="lazy"` on hotel cards
- lazy load flag and experience images in Morocco section
- add lazy attribute to service icons and other assets
- lazy load images across pages to lighten initial load

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859e9fcdbbc8323914f7825c5d63c51