### PR TITLE
Fix widget not switching after selecting service

### DIFF
--- a/src/components/booking/BookingWidget.jsx
+++ b/src/components/booking/BookingWidget.jsx
@@ -17,7 +17,7 @@ const BookingWidget = () => {
       switchWidget(service);
     }
     // Only run this effect when the query parameter changes
-  }, [searchParams, activeWidget, switchWidget]);
+  }, [searchParams]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- adjust booking widget useEffect dependencies so chosen service can change

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859fa3958a883238052c6891f065b82