### PR TITLE
Optimize LocalExp images

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logos/mainlogo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preload" as="image" href="/images/MarrakechLuxuryRiads.jpg" />
+    <link rel="preload" as="image" href="/images/SaharaDesertAdventures.jpg" />
+    <link rel="preload" as="image" href="/images/AtlasMountainTrekking.jpg" />
+    <link rel="preload" as="image" href="/images/EssaouiraCoastalCharm.jpg" />
+    <link rel="preload" as="image" href="/images/FesCulturalImmersion.jpg" />
+    <link rel="preload" as="image" href="/images/ChefchaouenBlueCity.jpg" />
     <title>FlyAndRoom</title>
   </head>
   <body>

--- a/src/components/sections/MoroccoSection.jsx
+++ b/src/components/sections/MoroccoSection.jsx
@@ -38,6 +38,8 @@ const MoroccoSection = () => {
                 alt="Morocco flag"
                 className="w-6 h-6 ml-2 inline-block"
                 loading="eager"
+                decoding="async"
+                fetchpriority="high"
               />
             </span>
           </h2>
@@ -56,6 +58,8 @@ const MoroccoSection = () => {
                   alt={exp.title}
                   className="h-32 w-full object-cover"
                   loading="eager"
+                  decoding="async"
+                  fetchpriority="high"
                 />
                 <div className="p-4">
                   <h3 className="text-lg font-bold mb-2">{exp.title}</h3>

--- a/src/pages/LocalExpPage.jsx
+++ b/src/pages/LocalExpPage.jsx
@@ -29,6 +29,8 @@ const LocalExpPage = () => {
               alt={exp.title}
               className="h-48 w-full object-cover"
               loading="eager"
+              decoding="async"
+              fetchpriority="high"
             />
             <div className="p-6">
               <h3 className="text-xl font-bold mb-2">{exp.title}</h3>


### PR DESCRIPTION
## Summary
- preload local experience images in `index.html`
- improve image fetch priority in LocalExpPage and MoroccoSection
- run lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859fe1168e08323a5b943f9286215c6