### PR TITLE
Add cookie consent banner

### DIFF
--- a/src/components/CookieBanner.jsx
+++ b/src/components/CookieBanner.jsx
@@ -1,0 +1,35 @@
+import React, { useState, useEffect } from 'react';
+
+const CookieBanner = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem('cookieConsent');
+    if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  const acceptCookies = () => {
+    localStorage.setItem('cookieConsent', 'true');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 inset-x-0 bg-gray-800 text-white p-4 flex flex-col sm:flex-row items-center justify-between z-50">
+      <p className="mb-2 sm:mb-0 text-center sm:text-left text-sm">
+        This website uses cookies to enhance the user experience.
+      </p>
+      <button
+        onClick={acceptCookies}
+        className="bg-primary text-white px-4 py-2 rounded hover:bg-primary/80"
+      >
+        Accept
+      </button>
+    </div>
+  );
+};
+
+export default CookieBanner;

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Navbar from './Navbar';
 import Footer from './Footer';
+import CookieBanner from '../CookieBanner';
 
 const Layout = ({ children }) => {
   return (
@@ -17,6 +18,7 @@ const Layout = ({ children }) => {
         </div>
       </main>
       <Footer />
+      <CookieBanner />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- create CookieBanner component
- include CookieBanner in Layout to show consent banner on page load

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a0504e03083238288a2033e10e20c