### PR TITLE
Add sunset view image and icon

### DIFF
--- a/src/components/SaharaDesertDetails.jsx
+++ b/src/components/SaharaDesertDetails.jsx
@@ -116,8 +116,31 @@ const SaharaDesertDetails = () => {
             </div>
           </div>
         </li>
-        <li>
-          <strong>Sunset Views:</strong> Watch the sun set over the vast desert landscape — a truly breathtaking sight.
+        <li className="flex items-start flex-col">
+          <div className="flex items-start">
+            <img
+              src="/icons/saharanighticon.png"
+              alt="Sunset icon"
+              className="w-5 h-5 mr-2 inline"
+              loading="lazy"
+            />
+            <span>
+              <strong>Sunset Views:</strong> Watch the sun set over the vast desert landscape — a truly breathtaking sight.
+            </span>
+          </div>
+          <div className="mt-2">
+            <div
+              className="bg-white rounded-xl overflow-hidden shadow-lg w-40 cursor-pointer"
+              onClick={() => setOpenImage('/images/Sahara-Desert-night.jpg')}
+            >
+              <img
+                src="/images/Sahara-Desert-night.jpg"
+                alt="Sunset Views"
+                className="h-28 w-full object-cover"
+                loading="lazy"
+              />
+            </div>
+          </div>
         </li>
       </ul>
 


### PR DESCRIPTION
## Summary
- display an icon for the "Sunset Views" feature
- add an image for "Sunset Views" with the same interactive styling as other experiences

## Testing
- `npm run lint`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac7e0e9cc832394918b9acaedd2c8