### PR TITLE
Keep booking widget mounted for faster return visits

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,9 +1,21 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import Navbar from './Navbar';
 import Footer from './Footer';
 import CookieBanner from '../CookieBanner';
+import BookingWidget from '../booking/BookingWidget';
 
 const Layout = ({ children }) => {
+  const location = useLocation();
+  const isHome = location.pathname === '/';
+  const [widgetMounted, setWidgetMounted] = useState(isHome);
+
+  useEffect(() => {
+    if (isHome) {
+      setWidgetMounted(true);
+    }
+  }, [isHome]);
+
   return (
     <div className="relative flex flex-col min-h-screen bg-[#F6F7EA]">
       <Navbar />
@@ -13,6 +25,15 @@ const Layout = ({ children }) => {
           aria-hidden="true"
           className="absolute inset-0 bg-[#F6F7EA] pointer-events-none"
         ></div>
+        {widgetMounted && (
+          <div
+            className={`container mx-auto px-4 mt-6 mb-12 sm:mt-8 md:mt-10 ${
+              isHome ? '' : 'hidden'
+            }`}
+          >
+            <BookingWidget />
+          </div>
+        )}
         <div className="relative">
           {children}
         </div>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,14 +1,10 @@
 import React from 'react';
-import BookingWidget from '../components/booking/BookingWidget';
 import MoroccoSection from '../components/sections/MoroccoSection';
 import PartnersSection from '../components/sections/PartnersSection';
 
 const HomePage = () => {
   return (
     <div className="py-6">
-      <div className="container mx-auto px-4 mt-6 mb-12 sm:mt-8 md:mt-10">
-        <BookingWidget />
-      </div>
       <MoroccoSection />
       <PartnersSection />
     </div>


### PR DESCRIPTION
## Summary
- keep the booking widget mounted inside `Layout` so navigating away and back doesn't reload it
- only render the widget once it has been seen at least once
- remove widget from `HomePage`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685acea80b788323ae361703069b13d8