### PR TITLE
Fix booking widget regression

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,21 +1,9 @@
-import React, { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import React from 'react';
 import Navbar from './Navbar';
 import Footer from './Footer';
 import CookieBanner from '../CookieBanner';
-import BookingWidget from '../booking/BookingWidget';
 
 const Layout = ({ children }) => {
-  const location = useLocation();
-  const isHome = location.pathname === '/';
-  const [widgetMounted, setWidgetMounted] = useState(isHome);
-
-  useEffect(() => {
-    if (isHome) {
-      setWidgetMounted(true);
-    }
-  }, [isHome]);
-
   return (
     <div className="relative flex flex-col min-h-screen bg-[#F6F7EA]">
       <Navbar />
@@ -25,15 +13,6 @@ const Layout = ({ children }) => {
           aria-hidden="true"
           className="absolute inset-0 bg-[#F6F7EA] pointer-events-none"
         ></div>
-        {widgetMounted && (
-          <div
-            className={`container mx-auto px-4 mt-6 mb-12 sm:mt-8 md:mt-10 ${
-              isHome ? '' : 'hidden'
-            }`}
-          >
-            <BookingWidget />
-          </div>
-        )}
         <div className="relative">
           {children}
         </div>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,10 +1,14 @@
 import React from 'react';
+import BookingWidget from '../components/booking/BookingWidget';
 import MoroccoSection from '../components/sections/MoroccoSection';
 import PartnersSection from '../components/sections/PartnersSection';
 
 const HomePage = () => {
   return (
     <div className="py-6">
+      <div className="container mx-auto px-4 mt-6 mb-12 sm:mt-8 md:mt-10">
+        <BookingWidget />
+      </div>
       <MoroccoSection />
       <PartnersSection />
     </div>


### PR DESCRIPTION
## Summary
- show booking widget within HomePage again
- revert Layout component to simple wrapper

## Testing
- `npm run lint`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad00045e48323a9154ea7a5a0efbb