### PR TITLE
Fix missing site title in navigation and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/logos/triploro-logo.svg" />
+    <link rel="icon" type="image/svg+xml" href="/logos/triploro-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preload" as="image" href="/images/MarrakechLuxuryRiads.jpg" />
     <link rel="preload" as="image" href="/images/SaharaDesertAdventures.jpg" />
@@ -10,7 +10,7 @@
     <link rel="preload" as="image" href="/images/EssaouiraCoastalCharm.jpg" />
     <link rel="preload" as="image" href="/images/FesCulturalImmersion.jpg" />
     <link rel="preload" as="image" href="/images/ChefchaouenBlueCity.jpg" />
-    <title>Triploro</title>
+    <title>Triploro.com</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/logos/triploro-icon.svg
+++ b/public/logos/triploro-icon.svg
@@ -1,0 +1,6 @@
+<!-- Enlarged favicon for better visibility on browser tabs -->
+<svg width="512" height="512" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
+  <!-- Compass rose -->
+  <polygon points="30,30 30,50 40,40" fill="#FFC300"/>
+  <polygon points="30,50 30,30 20,40" fill="#276EF1"/>
+</svg>

--- a/public/logos/triploro-logo.svg
+++ b/public/logos/triploro-logo.svg
@@ -1,6 +1,10 @@
-<!-- Enlarged favicon for better visibility on browser tabs -->
-<svg width="512" height="512" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
+<svg width="300" height="80" viewBox="0 0 300 80" xmlns="http://www.w3.org/2000/svg">
   <!-- Compass rose -->
   <polygon points="30,30 30,50 40,40" fill="#FFC300"/>
   <polygon points="30,50 30,30 20,40" fill="#276EF1"/>
+  
+  <!-- Text -->
+  <text x="50" y="50" font-family="Verdana, sans-serif" font-size="32" fill="#272724">
+    <tspan font-weight="bold">Trip</tspan>loro
+  </text>
 </svg>

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -16,13 +16,14 @@ const Footer = () => {
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row justify-between items-center">
           <div className="mb-6 md:mb-0">
-          <Link to="/" className="flex items-center hover:no-underline">
+          <Link to="/" className="flex items-center hover:no-underline space-x-2">
   <img
     src="/logos/triploro-logo.svg"
     alt="Triploro.com Logo"
     className="h-16 sm:h-20 md:h-24 w-auto"
     loading="eager"
   />
+  <span className="text-xl md:text-2xl font-semibold text-gray-800">Triploro.com</span>
 </Link>
               <p className="mt-2 text-gray-600 max-w-md text-sm md:text-base">
               Your trusted partner for flights, hotels, and car rentals in Morocco and beyond.

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -21,6 +21,7 @@ const Navbar = () => {
             setMobileMenuOpen(false);
             window.scrollTo({ top: 0, behavior: 'smooth' });
           }}
+          className="flex items-center space-x-2"
         >
           <img
             src="/logos/triploro-logo.svg"
@@ -28,6 +29,7 @@ const Navbar = () => {
             className="h-12 md:h-16 transform scale-125 origin-left"
             loading="eager"
           />
+          <span className="text-lg md:text-xl font-semibold text-gray-800">Triploro.com</span>
         </Link>
         
         {/* Desktop Navigation */}


### PR DESCRIPTION
## Summary
- restore `Triploro.com` page title
- display brand name next to icon in navbar and footer
- restore original logo with text
- add icon-only SVG for favicon

## Testing
- `npm run lint`
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3271383c8323b532f77711ea78d4