### PR TITLE
Unify Local Experience card image style

### DIFF
--- a/src/components/LocalExpCard.jsx
+++ b/src/components/LocalExpCard.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const LocalExpCard = ({ experience }) => {
+  return (
+    <Link
+      to={`/local-exp/${experience.slug}`}
+      className="bg-white rounded-xl overflow-hidden shadow-lg transition-transform hover:scale-[1.02]"
+    >
+      <img
+        src={experience.image ? experience.image : `/localexp/${experience.slug}.svg`}
+        alt={experience.title}
+        className="h-48 w-full object-cover"
+        loading="eager"
+        decoding="async"
+        fetchpriority="high"
+      />
+      <div className="p-6">
+        <h3 className="text-xl font-bold mb-2">{experience.title}</h3>
+        <p className="text-gray-600 mb-4">{experience.description}</p>
+        <span className="text-primary font-semibold hover:underline">
+          Discover Experience
+        </span>
+      </div>
+    </Link>
+  );
+};
+
+export default LocalExpCard;

--- a/src/pages/LocalExpPage.jsx
+++ b/src/pages/LocalExpPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { localExperiences } from '../data/localExperiences.jsx';
+import LocalExpCard from '../components/LocalExpCard.jsx';
 
 const LocalExpPage = () => {
   const experiences = localExperiences;
@@ -19,27 +19,7 @@ const LocalExpPage = () => {
       
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
         {experiences.map((exp, index) => (
-          <Link
-            key={index}
-            to={`/local-exp/${exp.slug}`}
-            className="bg-white rounded-xl overflow-hidden shadow-2xl transition-transform hover:scale-[1.02]"
-          >
-            <img
-              src={exp.image ? exp.image : `/localexp/${exp.slug}.svg`}
-              alt={exp.title}
-              className="h-48 w-full object-cover"
-              loading="eager"
-              decoding="async"
-              fetchpriority="high"
-            />
-            <div className="p-6">
-              <h3 className="text-xl font-bold mb-2">{exp.title}</h3>
-              <p className="text-gray-600 mb-4">{exp.description}</p>
-              <span className="text-primary font-semibold hover:underline">
-                Discover Experience
-              </span>
-            </div>
-          </Link>
+          <LocalExpCard key={index} experience={exp} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- introduce `LocalExpCard` component matching the style of `HotelCard`
- refactor `LocalExpPage` to use the new component for uniform card images

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d6ff97b6483239fe77a9014b4a8ad