### PR TITLE
Set tapicon as favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/logos/triploro-icon.svg" />
+    <!-- Updated favicon -->
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="320x320"
+      href="/icons/tapicon.png"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preload" as="image" href="/images/MarrakechLuxuryRiads.jpg" />
     <link rel="preload" as="image" href="/images/SaharaDesertAdventures.jpg" />


### PR DESCRIPTION
## Summary
- use `public/icons/tapicon.png` as the site favicon
- mark it with a bigger size declaration

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d7d07091c83239d36a005d84e22c1